### PR TITLE
fix service target

### DIFF
--- a/rootfs/usr/lib/systemd/user/xdg-desktop-portal-openuri.service
+++ b/rootfs/usr/lib/systemd/user/xdg-desktop-portal-openuri.service
@@ -5,4 +5,4 @@ Description=xdg-desktop-portal-openuri Service
 ExecStart=/usr/bin/xdg-desktop-portal-openuri
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
This is a user service, so `multi-user.target` is not a thing. Change to a more appropriate target: `graphical-session.target` - also used by playserve.